### PR TITLE
fix(deps): bump js-yaml to 3.15.1 to patch CVE-2026-59869

### DIFF
--- a/packages/openg-cli/package-lock.json
+++ b/packages/openg-cli/package-lock.json
@@ -4971,9 +4971,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/openg/package-lock.json
+++ b/packages/openg/package-lock.json
@@ -4973,9 +4973,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Fixes the high-severity Dependabot alerts for [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / CVE-2026-59869: **js-yaml — YAML merge-key chains can force quadratic CPU consumption.**

- `packages/openg-cli/package-lock.json`: js-yaml `3.14.2` → `3.15.1`
- `packages/openg/package-lock.json`: js-yaml `3.14.2` → `3.15.1`

Lockfile-only change — js-yaml is a transitive dependency and the depending range (`^3.5.1`) already admits the patched version. No `package.json` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)